### PR TITLE
ci: use fine-grained PAT for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-python@v6
         with:
@@ -26,4 +27,4 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Use `RELEASE_TOKEN` (fine-grained PAT) instead of `GITHUB_TOKEN` for semantic-release
- `GITHUB_TOKEN` cannot bypass branch rulesets on personal repos, causing the release workflow to fail on `git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)